### PR TITLE
Assert callback can create custom response

### DIFF
--- a/src/SamlController.ts
+++ b/src/SamlController.ts
@@ -45,7 +45,11 @@ exports.assert = (
 
       if (onAssertRes) {
         // the callback shall return the reply object after using it to redirect/response.
-        return onAssertRes(profile, request, reply).state(cookieName, profile);      
+        const replyFromCallback = onAssertRes(profile, request, reply).state(cookieName, profile);
+        if(replyFromCallback) {
+          return replyFromCallback.state(cookieName, profile);
+        }
+        return reply.state(cookieName, profile).code(200);
       }
 
       throw new Error('onAssert is missing');

--- a/src/SamlController.ts
+++ b/src/SamlController.ts
@@ -44,10 +44,8 @@ exports.assert = (
       }
 
       if (onAssertRes) {
-        let session = request.state[cookieName];
-        const updated = onAssertRes(profile,  request);
-        session[samlCredsPropKey] = updated;
-        return reply.redirect(session.redirectTo).state(cookieName, session);
+        // the callback shall return the reply object after using it to redirect/response.
+        return onAssertRes(profile, request, reply).state(cookieName, profile);      
       }
 
       throw new Error('onAssert is missing');


### PR DESCRIPTION
After the SAML authentication is concluded, the application needs to be free to create a custom response. Moreover, if you just redirect, cookies won't be set (Chrome).
Now the reply object is given to the callback as an extra argument, and it should always be returned to the caller too.